### PR TITLE
Add hardware teleop launch + hardware/base image deps

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -20,5 +20,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Initialize rosdep (ignore failure in empty container)
 RUN rosdep update || true
 
+# ROS 2 packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-jazzy-joy \
+    ros-jazzy-teleop-twist-joy \
+    && rm -rf /var/lib/apt/lists/*
+
 # Workspace root (this will be volume-mounted)
 WORKDIR /workspace

--- a/docker/hardware/Dockerfile
+++ b/docker/hardware/Dockerfile
@@ -5,6 +5,23 @@ FROM maly_woz/base:jazzy
 # Copy from your repo into /etc/udev/rules.d/
 #COPY src/robot/my_robot_hw_drivers/udev_rules/*.rules /etc/udev/rules.d/
 
+# RPi packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3-rpi.gpio \
+    ros-jazzy-camera-ros \
+    && rm -rf /var/lib/apt/lists/*
+
+# libcamera
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3-pip git python3-jinja2 \
+    libboost-dev \
+    libgnutls28-dev openssl libtiff-dev pybind11-dev \
+    qtbase5-dev libqt5core5a libqt5widgets5 \
+    meson cmake \
+    python3-yaml python3-ply \
+    libglib2.0-dev libgstreamer-plugins-base1.0-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 # Source ROS automatically
 SHELL ["/bin/bash", "-c"]
 RUN echo "source /opt/ros/jazzy/setup.bash" >> ~/.bashrc

--- a/src/maly_woz_hw/launch/hw.launch.py
+++ b/src/maly_woz_hw/launch/hw.launch.py
@@ -1,0 +1,38 @@
+from launch import LaunchDescription
+
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    ff_control = Node(
+        package="maly_woz_hw",
+        executable="ff_control",
+    )
+
+    # TODO load depending on parameter
+    joy_node = Node(
+        package="joy",
+        executable="joy_node",
+    )
+
+    joy_teleop_node = Node(
+        package="teleop_twist_joy",
+        executable="teleop_node",
+        parameters=[
+            {
+                "require_enable_button": False,
+                "axis_linear": {"x": 3},
+                "scale_linear": {"x": 1.0},
+                "axis_angular": {"yaw": 2},
+            }
+        ],
+        # remappings=[("cmd_vel", "/model/rover/cmd_vel")],
+    )
+
+    return LaunchDescription(
+        [
+            joy_node,
+            joy_teleop_node,
+            ff_control,
+        ]
+    )

--- a/src/maly_woz_hw/package.xml
+++ b/src/maly_woz_hw/package.xml
@@ -10,6 +10,8 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>joy</exec_depend>
+  <exec_depend>teleop_twist_joy</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/src/maly_woz_hw/setup.py
+++ b/src/maly_woz_hw/setup.py
@@ -9,6 +9,7 @@ setup(
     data_files=[
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
         ("share/" + package_name, ["package.xml"]),
+        ("share/" + package_name + "/launch", ["launch/hw.launch.py"]),
     ],
     install_requires=["setuptools"],
     zip_safe=True,


### PR DESCRIPTION
Salvaged from the old launch-files branch onto current master:
- maly_woz_hw hw.launch.py: joy_node + teleop_twist_joy + ff_control, installed via setup.py and declared in package.xml (joy, teleop_twist_joy).
- base image: install ros-jazzy-joy / ros-jazzy-teleop-twist-joy.
- hardware image: install RPi GPIO, camera-ros and libcamera build deps.